### PR TITLE
variable fullnames: s/-/|/g

### DIFF
--- a/src/hierarchical-variables/i-generate-variable-full-name.js
+++ b/src/hierarchical-variables/i-generate-variable-full-name.js
@@ -13,7 +13,7 @@ function IGenerateVariableFullNameFactory() {
 
         while(parent.hierarchicalType === 'variable' ||
             (parent.parent && parent.parent.name !== 'graph')) {
-            fullName = parent.name + ' - ' + fullName
+            fullName = parent.name + ' | ' + fullName
             parent = parent.parent
         }
 

--- a/src/hierarchical-variables/tests/i-generate-variable-full-name-spec.js
+++ b/src/hierarchical-variables/tests/i-generate-variable-full-name-spec.js
@@ -70,7 +70,7 @@ describe('iGenerateVariableFullName', function() {
             })
 
             it('should return the variable name along with its n-1 parent names', function() {
-                fullName.should.be.equal('lvl 1 - lvl 2 - var name')
+                fullName.should.be.equal('lvl 1 | lvl 2 | var name')
             })
         })
 
@@ -97,7 +97,7 @@ describe('iGenerateVariableFullName', function() {
             })
 
             it('should not consider the graph as parent of the hierarchy', function() {
-                fullName.should.be.equal('lvl 1 - lvl 2 - var name')
+                fullName.should.be.equal('lvl 1 | lvl 2 | var name')
             })
         })
 
@@ -124,7 +124,7 @@ describe('iGenerateVariableFullName', function() {
             })
 
             it('should not consider the graph as parent of the hierarchy', function() {
-                fullName.should.be.equal('lvl 1 - lvl 2 - var name')
+                fullName.should.be.equal('lvl 1 | lvl 2 | var name')
             })
         })
 
@@ -146,7 +146,7 @@ describe('iGenerateVariableFullName', function() {
             })
 
             it('should always consider the subvariable parent', function() {
-                fullName.should.be.equal('array - var name')
+                fullName.should.be.equal('array | var name')
             })
         })
     })


### PR DESCRIPTION
> On Friday, April 24, 2015, Douglas Rivers <doug@crunch.io> wrote:
It applies to all levels of naming, but wouldn’t apply if “programs” were just a group name. We wouldn’t want “Gender” to become “Demographics | Gender”.


> On Apr 24, 2015, at 4:34 PM, Mike Malecki <mike@crunch.io> wrote:
>
> I agree that
> “Array | Subvariable”
> is right. Do you think that applies for all levels of nesting? (I think so)
>
> Example:
> Programs | ITV | Downton Abbey
> >
> Programs - ITV | Downton Abbey
>
> Yeah?