### PR TITLE
Recalculate number of pages where the group's items fit in

### DIFF
--- a/src/hierarchical-variables-list/hierarchical-group.js
+++ b/src/hierarchical-variables-list/hierarchical-group.js
@@ -96,6 +96,8 @@ function HierarchicalGroupFactory(machina, HierarchicalVariable, Traversable) {
                 return item
             })
 
+            this.retraversable(this, 'items')
+
             return this
         }
         ,states: {
@@ -111,7 +113,7 @@ function HierarchicalGroupFactory(machina, HierarchicalVariable, Traversable) {
     })
 
     var HierarchicalGroup = HierarchicalGroupBase.extend({
-        initialize: function(cfg) {
+        initialize: function() {
             this.items = []
             this._traversable = new Traversable({
                 pageLength: this.threshold || 40

--- a/src/hierarchical-variables-list/tests/hierarchical-group-spec.js
+++ b/src/hierarchical-variables-list/tests/hierarchical-group-spec.js
@@ -1,0 +1,66 @@
+'use strict'
+
+var mocks = require('angular-mocks')
+    , machinaMod = require('../../machina-angular')
+    , traversableMod = require('../../traversable')
+    , mainMod = require('../index')
+    , mockHierarchicalVariables = require('../../test-support/mock-hierarchical-variables')
+    ,fixtures = {
+        variables: require('../../hierarchical-variables/tests/variables')
+        ,hierarchicalUngrouped : require('../../hierarchical-variables/tests/hierarchical-ungrouped')
+    }
+    ;
+
+describe('HierarchicalGroup', function() {
+    var sut
+        ;
+
+    function buildModule() {
+        var main = mainMod()
+            , machina = machinaMod()
+            , traversable = traversableMod()
+            ;
+
+        main.factory('bus', function() {return {}})
+
+        mockHierarchicalVariables.registerModule()
+
+        angular.mock.module(main.name, machina.name, traversable.name)
+    }
+
+    function buildSut() {
+        angular.mock.inject(function(HierarchicalGroup, hierarchicalBehaviors) {
+            var hv = mockHierarchicalVariables.getHierarchicalVariablesObj(
+                undefined
+                , fixtures.variables
+                , fixtures.hierarchicalUngrouped
+            )
+
+            sut = HierarchicalGroup.create({
+                group : hv.ordered
+                , behaviors : hierarchicalBehaviors.DEFAULT()
+            })
+        })
+    }
+
+    beforeEach(buildModule)
+    beforeEach(buildSut)
+
+    context('when applying new hierarchical behaviors', function() {
+
+        context('given the hierarchical behaviors are filtering items by their type', function() {
+            beforeEach(function() {
+                sut.handle('expand')
+                inject(function(hierarchicalBehaviors) {
+                    sut.applyBehaviors(hierarchicalBehaviors({
+                        types : ['numeric']
+                    }))
+                })
+            })
+
+            it('should recalculate the number of pages where items fit', function() {
+                expect(sut.incrementable).to.be.false
+            })
+        })
+    })
+})


### PR DESCRIPTION
When the items in the variable accordion are filtered by type, the number of items is reduced but the number of pages is not recalculated. This PR fixes the issue.