### PR TITLE
Avoid drop style flickering

### DIFF
--- a/src/drag-and-drop/dropit-directive.js
+++ b/src/drag-and-drop/dropit-directive.js
@@ -15,6 +15,8 @@ function DropItDirective(dragAndDrop, $log){
             var elm = el[0]
                 ,classList = elm.classList
                 , applied = false
+                , enterTime = 0
+                , enterTarget
                 ;
 
             elm.setAttribute('droppable','true')
@@ -30,7 +32,8 @@ function DropItDirective(dragAndDrop, $log){
                     applied = true
                 }
             }
-            function removeClass(e) {
+
+             function removeClass(e) {
                 if(applied) {
                     classList.remove(discoverDroppableClass())
                     applied = false
@@ -68,11 +71,11 @@ function DropItDirective(dragAndDrop, $log){
                 e.dataTransfer.dropEffect = 'all'
                 //yup, this fires way too much
                 applyClass(e)
-
                 scope.$broadcast('dragover')
             }
 
             function onDragEnter(e) {
+                enterTarget = e.currentTarget
                 $log.debug('drag-and-drop','drop','dragenter',e)
                 if(e.preventDefault){
                     e.preventDefault()
@@ -81,20 +84,32 @@ function DropItDirective(dragAndDrop, $log){
                     e.stopPropagation()
                 }
 
+                enterTime = performance.now()
+
                 //yup..this is interrupted by a bug
                 //applyClass(e)
             }
             function onDragLeave(e){
-                $log.debug('drag-and-drop','drop','dragleave',e)
+                var enterLeaveInterval = performance.now() - enterTime
                 if(e.preventDefault){
                     e.preventDefault()
                 }
+
                 if(e.stopPropagation){
                     e.stopPropagation()
                 }
-                removeClass(e)
 
-                scope.$broadcast('dragleave')
+                /*
+                This event is triggered many times, even with the slighest change
+                in the draggable's position. Since enter and leave events happen
+                within really small intervals, the drag enter style flickers and
+                the UI enters in an inconsistent state. This condition verifies
+                that the class is only remove is
+                 */
+                if(enterLeaveInterval > 1) {
+                    removeClass(e)
+                    scope.$broadcast('dragleave')
+                }
             }
 
 

--- a/src/drag-and-drop/dropit-directive.js
+++ b/src/drag-and-drop/dropit-directive.js
@@ -16,7 +16,6 @@ function DropItDirective(dragAndDrop, $log){
                 ,classList = elm.classList
                 , applied = false
                 , enterTime = 0
-                , enterTarget
                 ;
 
             elm.setAttribute('droppable','true')
@@ -75,7 +74,6 @@ function DropItDirective(dragAndDrop, $log){
             }
 
             function onDragEnter(e) {
-                enterTarget = e.currentTarget
                 $log.debug('drag-and-drop','drop','dragenter',e)
                 if(e.preventDefault){
                     e.preventDefault()


### PR DESCRIPTION
The time interval between the triggering of drag enter and drag leave events in an element with an small size is usually insignificant (really close to 0). When add the drag-enter css class selector when the drag enter is triggered and remove it when the drag leave event is triggered. Since the stability of these events is really slow on elements with small size, they're usually triggered many times which causes a flickering effect (depending on the style assigned to the drag-over css selector). 

This PR tries to avoid this by removing the css class, only if the time interval between the 2 events is larger than 1.